### PR TITLE
Add go version flag for backwards compatibility

### DIFF
--- a/cmd/gobump/root.go
+++ b/cmd/gobump/root.go
@@ -13,10 +13,11 @@ import (
 )
 
 type rootCLIFlags struct {
-	packages string
-	modroot  string
-	replaces string
-	tidy     bool
+	packages  string
+	modroot   string
+	replaces  string
+	goVersion string
+	tidy      bool
 }
 
 var rootFlags rootCLIFlags
@@ -72,7 +73,7 @@ var rootCmd = &cobra.Command{
 			}
 		}
 
-		if _, err := update.DoUpdate(pkgVersions, rootFlags.modroot, rootFlags.tidy); err != nil {
+		if _, err := update.DoUpdate(pkgVersions, rootFlags.modroot, rootFlags.tidy, rootFlags.goVersion); err != nil {
 			fmt.Println("failed running update: ", err)
 			os.Exit(1)
 		}
@@ -93,4 +94,5 @@ func init() {
 	flagSet.StringVar(&rootFlags.modroot, "modroot", "", "path to the go.mod root")
 	flagSet.StringVar(&rootFlags.replaces, "replaces", "", "A space-separated list of packages to replace")
 	flagSet.BoolVar(&rootFlags.tidy, "tidy", false, "Run 'go mod tidy' command")
+	flagSet.StringVar(&rootFlags.goVersion, "go-version", "", "set the go-version for go-mod-tidy")
 }

--- a/pkg/update/update.go
+++ b/pkg/update/update.go
@@ -65,10 +65,10 @@ func checkPackageValues(pkgVersions map[string]*types.Package, modFile *modfile.
 	return nil
 }
 
-func DoUpdate(pkgVersions map[string]*types.Package, modroot string, tidy bool) (*modfile.File, error) {
+func DoUpdate(pkgVersions map[string]*types.Package, modroot string, tidy bool, goVersion string) (*modfile.File, error) {
 	// Run go mod tidy before
 	if tidy {
-		output, err := run.GoModTidy(modroot)
+		output, err := run.GoModTidy(modroot, goVersion)
 		if err != nil {
 			return nil, fmt.Errorf("failed to run 'go mod tidy': %v with output: %v", err, output)
 		}
@@ -117,7 +117,7 @@ func DoUpdate(pkgVersions map[string]*types.Package, modroot string, tidy bool) 
 
 	// Run go mod tidy
 	if tidy {
-		output, err := run.GoModTidy(modroot)
+		output, err := run.GoModTidy(modroot, goVersion)
 		if err != nil {
 			return nil, fmt.Errorf("failed to run 'go mod tidy': %v with output: %v", err, output)
 		}

--- a/pkg/update/update_test.go
+++ b/pkg/update/update_test.go
@@ -44,7 +44,7 @@ func TestUpdate(t *testing.T) {
 			tmpdir := t.TempDir()
 			copyFile(t, "testdata/aws-efs-csi-driver/go.mod", tmpdir)
 
-			modFile, err := DoUpdate(tc.pkgVersions, tmpdir, false)
+			modFile, err := DoUpdate(tc.pkgVersions, tmpdir, false, "")
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -84,7 +84,7 @@ func TestGoModTidy(t *testing.T) {
 			copyFile(t, "testdata/hello/go.sum", tmpdir)
 			copyFile(t, "testdata/hello/main.go", tmpdir)
 
-			modFile, err := DoUpdate(tc.pkgVersions, tmpdir, true)
+			modFile, err := DoUpdate(tc.pkgVersions, tmpdir, true, "")
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -118,7 +118,7 @@ func TestUpdateError(t *testing.T) {
 			tmpdir := t.TempDir()
 			copyFile(t, "testdata/aws-efs-csi-driver/go.mod", tmpdir)
 
-			_, err := DoUpdate(tc.pkgVersions, tmpdir, false)
+			_, err := DoUpdate(tc.pkgVersions, tmpdir, false, "")
 			if err == nil {
 				t.Fatal("expected error, got nil")
 			}
@@ -138,7 +138,7 @@ func TestReplaces(t *testing.T) {
 			Replace: true,
 		}}
 
-	modFile, err := DoUpdate(replaces, tmpdir, false)
+	modFile, err := DoUpdate(replaces, tmpdir, false, "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -199,7 +199,7 @@ func TestCommit(t *testing.T) {
 					Version: tc.version,
 				},
 			}
-			modFile, err := DoUpdate(pkgVersions, tmpdir, false)
+			modFile, err := DoUpdate(pkgVersions, tmpdir, false, "1.21")
 			if err != nil {
 				t.Fatal(err)
 			}


### PR DESCRIPTION
To respect the backwards compatibility, we need to add a go-version flag to use it if provided in the go/bump pipeline.