### PR TITLE
[DNM]: show diffs between the original and new go.mod file

### DIFF
--- a/cmd/gobump/root.go
+++ b/cmd/gobump/root.go
@@ -18,6 +18,7 @@ type rootCLIFlags struct {
 	replaces  string
 	goVersion string
 	tidy      bool
+	showDiff  bool
 }
 
 var rootFlags rootCLIFlags
@@ -73,7 +74,7 @@ var rootCmd = &cobra.Command{
 			}
 		}
 
-		if _, err := update.DoUpdate(pkgVersions, rootFlags.modroot, rootFlags.tidy, rootFlags.goVersion); err != nil {
+		if _, err := update.DoUpdate(pkgVersions, &types.Config{Modroot: rootFlags.modroot, Tidy: rootFlags.tidy, GoVersion: rootFlags.goVersion, ShowDiff: rootFlags.showDiff}); err != nil {
 			fmt.Println("failed running update: ", err)
 			os.Exit(1)
 		}
@@ -94,5 +95,6 @@ func init() {
 	flagSet.StringVar(&rootFlags.modroot, "modroot", "", "path to the go.mod root")
 	flagSet.StringVar(&rootFlags.replaces, "replaces", "", "A space-separated list of packages to replace")
 	flagSet.BoolVar(&rootFlags.tidy, "tidy", false, "Run 'go mod tidy' command")
+	flagSet.BoolVar(&rootFlags.showDiff, "show-diff", false, "Show the difference between the original and 'go.mod' files")
 	flagSet.StringVar(&rootFlags.goVersion, "go-version", "", "set the go-version for go-mod-tidy")
 }

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/chainguard-dev/gobump
 go 1.21
 
 require (
+	github.com/google/go-cmp v0.6.0
 	github.com/spf13/cobra v1.8.0
 	golang.org/x/mod v0.14.0
 	k8s.io/apimachinery v0.29.0

--- a/go.sum
+++ b/go.sum
@@ -3,6 +3,8 @@ github.com/common-nighthawk/go-figure v0.0.0-20210622060536-734e95fb86be/go.mod 
 github.com/cpuguy83/go-md2man/v2 v2.0.3/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
+github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -7,3 +7,10 @@ type Package struct {
 	Replace bool
 	Require bool
 }
+
+type Config struct {
+	Modroot   string
+	GoVersion string
+	ShowDiff  bool
+	Tidy      bool
+}

--- a/pkg/update/update_test.go
+++ b/pkg/update/update_test.go
@@ -45,7 +45,7 @@ func TestUpdate(t *testing.T) {
 			tmpdir := t.TempDir()
 			copyFile(t, "testdata/aws-efs-csi-driver/go.mod", tmpdir)
 
-			modFile, err := DoUpdate(tc.pkgVersions, tmpdir, false, "")
+			modFile, err := DoUpdate(tc.pkgVersions, &types.Config{Modroot: tmpdir, Tidy: false, GoVersion: ""})
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -85,7 +85,7 @@ func TestGoModTidy(t *testing.T) {
 			copyFile(t, "testdata/hello/go.sum", tmpdir)
 			copyFile(t, "testdata/hello/main.go", tmpdir)
 
-			modFile, err := DoUpdate(tc.pkgVersions, tmpdir, true, "")
+			modFile, err := DoUpdate(tc.pkgVersions, &types.Config{Modroot: tmpdir, Tidy: false, GoVersion: ""})
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -119,7 +119,7 @@ func TestUpdateError(t *testing.T) {
 			tmpdir := t.TempDir()
 			copyFile(t, "testdata/aws-efs-csi-driver/go.mod", tmpdir)
 
-			_, err := DoUpdate(tc.pkgVersions, tmpdir, false, "")
+			_, err := DoUpdate(tc.pkgVersions, &types.Config{Modroot: tmpdir, Tidy: false, GoVersion: ""})
 			if err == nil {
 				t.Fatal("expected error, got nil")
 			}
@@ -139,7 +139,7 @@ func TestReplaces(t *testing.T) {
 			Replace: true,
 		}}
 
-	modFile, err := DoUpdate(replaces, tmpdir, false, "")
+	modFile, err := DoUpdate(replaces, &types.Config{Modroot: tmpdir, Tidy: false, GoVersion: ""})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -203,7 +203,7 @@ func TestCommit(t *testing.T) {
 					Version: tc.version,
 				},
 			}
-			modFile, err := DoUpdate(pkgVersions, tmpdir, false, "1.21")
+			modFile, err := DoUpdate(pkgVersions, &types.Config{Modroot: tmpdir, Tidy: false, GoVersion: "1.21"})
 			if err != nil {
 				t.Fatal(err)
 			}


### PR DESCRIPTION
I added a Config object to define a list of all the options when running the update command.

This new flag prints the different between the two go mod files, as shown below. This is interesting when debugging the changes and also understanding which deps got bumped despite of those included in the go/bump command.

```
 (
  	"""
  	... // 10 identical lines
  		code.gitea.io/gitea v1.17.2
  		github.com/Masterminds/squirrel v1.5.1
- 		github.com/adrg/xdg v0.3.2
+ 		github.com/adrg/xdg v0.4.0
  		github.com/aws/aws-sdk-go v1.44.322
  		github.com/bmatcuk/doublestar/v4 v4.6.0
  		github.com/coreos/go-semver v0.3.0
  		github.com/dchest/uniuri v0.0.0-20200228104902-7aecb25e1fe5
- 		github.com/drone-runners/drone-runner-docker v1.8.4-0.20231106161015-8c0240291f1d
+ 		github.com/drone-runners/drone-runner-docker v0.0.0-00010101000000-000000000000
  		github.com/drone/drone-go v1.7.1
  		github.com/drone/drone-yaml v1.2.3
  	... // 17 identical lines
  		github.com/hashicorp/go-multierror v1.1.1
  		github.com/jmoiron/sqlx v1.3.3
- 		github.com/joho/godotenv v1.3.0
+ 		github.com/joho/godotenv v1.5.1
  		github.com/kelseyhightower/envconfig v1.4.0
- 		github.com/lib/pq v1.10.5
+ 		github.com/lib/pq v1.10.7
  		github.com/maragudk/migrate v0.4.1
  		github.com/matoous/go-nanoid v1.5.0
  		github.com/matoous/go-nanoid/v2 v2.0.0
  		github.com/mattn/go-isatty v0.0.17
- 		github.com/mattn/go-sqlite3 v1.14.12
+ 		github.com/mattn/go-sqlite3 v1.14.16
  		github.com/pkg/errors v0.9.1
  		github.com/rs/xid v1.4.0
  		github.com/rs/zerolog v1.29.0
- 		github.com/sercand/kuberesolver/v5 v5.1.0
+ 		github.com/sercand/kuberesolver/v5 v5.1.1
  		github.com/stretchr/testify v1.8.4
  		github.com/swaggest/openapi-go v0.2.23
  		github.com/swaggest/swgui v1.4.2
  		github.com/unrolled/secure v1.0.8
- 		go.uber.org/multierr v1.8.0
- 		golang.org/x/crypto v0.13.0
+ 		go.uber.org/multierr v1.9.0
+ 		golang.org/x/crypto v0.17.0
  		golang.org/x/exp v0.0.0-20230108222341-4b8118a2686a
  		golang.org/x/oauth2 v0.10.0
  		golang.org/x/sync v0.3.0
- 		golang.org/x/term v0.12.0
- 		golang.org/x/text v0.13.0
+ 		golang.org/x/term v0.15.0
+ 		golang.org/x/text v0.14.0
  		google.golang.org/api v0.132.0
  		gopkg.in/alecthomas/kingpin.v2 v2.2.6
  	... // 3 identical lines
  	require (
  		cloud.google.com/go v0.110.4 // indirect
- 		cloud.google.com/go/compute v1.20.1 // indirect
+ 		cloud.google.com/go/compute v1.21.0 // indirect
  		cloud.google.com/go/compute/metadata v0.2.3 // indirect
- 		cloud.google.com/go/iam v1.1.0 // indirect
+ 		cloud.google.com/go/iam v1.1.1 // indirect
+ 		code.gitea.io/actions-proto-go v0.2.0 // indirect
  		dario.cat/mergo v1.0.0 // indirect
- 		gitea.com/go-chi/binding v0.0.0-20220309004920-114340dabecb // indirect
+ 		gitea.com/go-chi/binding v0.0.0-20221013104517-b29891619681 // indirect
  		gitea.com/go-chi/cache v0.2.0 // indirect
  		gitea.com/lunny/levelqueue v0.4.2-0.20220729054728-f020868cc2f7 // indirect
  		github.com/42wim/sshsig v0.0.0-20211121163825-841cf5bbc121 // indirect
  		github.com/99designs/httpsignatures-go v0.0.0-20170731043157-88528bf4ca7e // indirect
- 		github.com/RoaringBitmap/roaring v0.9.4 // indirect
- 		github.com/alecthomas/chroma v0.10.0 // indirect
+ 		github.com/RoaringBitmap/roaring v1.2.3 // indirect
+ 		github.com/alecthomas/chroma/v2 v2.4.0 // indirect
  		github.com/antonmedv/expr v1.15.2 // indirect
  		github.com/aymerick/douceur v0.2.0 // indirect
  		github.com/beorn7/perks v1.0.1 // indirect
- 		github.com/bgentry/speakeasy v0.1.0 // indirect
- 		github.com/bits-and-blooms/bitset v1.2.2 // indirect
- 		github.com/blevesearch/bleve/v2 v2.3.2 // indirect
- 		github.com/blevesearch/bleve_index_api v1.0.1 // indirect
+ 		github.com/bits-and-blooms/bitset v1.5.0 // indirect
+ 		github.com/blevesearch/bleve/v2 v2.3.6 // indirect
+ 		github.com/blevesearch/bleve_index_api v1.0.5 // indirect
+ 		github.com/blevesearch/geo v0.1.17 // indirect
  	... // 118 identical, 88 removed, and 62 inserted lines
  	"""
  )

```