### PR TITLE
go-version: use the version from the go.mod file

### DIFF
--- a/pkg/run/gorun.go
+++ b/pkg/run/gorun.go
@@ -22,10 +22,9 @@ func GoModTidy(modroot, goVersion string) (string, error) {
 
 		v := versionutil.MustParseGeneric(goVersion)
 		goVersion = fmt.Sprintf("%d.%d", v.Major(), v.Minor())
-
-		log.Printf("Running go mod tidy with go version '%s' ...\n", goVersion)
 	}
 
+	log.Printf("Running go mod tidy with go version '%s' ...\n", goVersion)
 	cmd := exec.Command("go", "mod", "tidy", "-go", goVersion)
 	cmd.Dir = modroot
 	if bytes, err := cmd.CombinedOutput(); err != nil {


### PR DESCRIPTION
Ideally use the go version from the go.mod file if it was not set in the flags. Otherwise use the go version in the environment.