### PR TITLE
Improve Errors and Update Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,14 +4,14 @@ GoBump is a simple command-line tool written in Go that allows you to update the
 ## Usage
 
 ```shell
-gobump --packages=<package@version>,... --modroot=<path to go.mod>
+gobump --packages=<package@version> ... --modroot=<path to go.mod>
 ```
 
 ### Flags
 
-* `--packages`: A comma-separated list of packages to update. Each package should be in the format `package@version`.
+* `--packages`: A space-separated list of packages to update. Each package should be in the format `package@version`.
 * `--modroot`: Path to the go.mod root. If not specified, it defaults to the current directory.
-* `--replaces`: A comma-separated list of packages to replace. Each entry should be in the format `old=new@version`.
+* `--replaces`: A space-separated list of packages to replace. Each entry should be in the format `old=new@version`.
 * `--go-version`: set the go-version for 'go mod tidy' command.
 * `--show-diff`: Show the difference between the original and 'go.mod' files.
 * `--tidy`:  Run 'go mod tidy' command.
@@ -19,7 +19,7 @@ gobump --packages=<package@version>,... --modroot=<path to go.mod>
 ## Example
 
 ```shell
-gobump --packages=github.com/pkg/errors@v0.9.1,golang.org/x/mod@v0.4.2 --modroot=/path/to/your/project
+gobump --packages="github.com/pkg/errors@v0.9.1 golang.org/x/mod@v0.4.2" --modroot=/path/to/your/project
 ```
 
 This will update the versions of `github.com/pkg/errors` and `golang.org/x/mod` in your `go.mod` file.


### PR DESCRIPTION
- Refactored the error handling to use `fmt.Errorf` instead of `log.Println` and `os.Exit`. This allows to return errors from the RunE function, which is a more idiomatic approach in Cobra applications.

- I've updated the README to reflect the changes in how the `--packages` and `--replaces` works now.