### PR TITLE
fix: handle deps that also appear in replaces blocks in the go.mod

### DIFF
--- a/pkg/update/testdata/bye/go.mod
+++ b/pkg/update/testdata/bye/go.mod
@@ -1,0 +1,12 @@
+module github.com/puerco/hello
+
+go 1.19
+
+require github.com/sirupsen/logrus v1.8.0
+
+replace github.com/sirupsen/logrus => github.com/sirupsen/logrus v1.3.0
+
+require (
+	github.com/magefile/mage v1.10.0 // indirect
+	golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8 // indirect
+)

--- a/pkg/update/testdata/bye/go.sum
+++ b/pkg/update/testdata/bye/go.sum
@@ -1,0 +1,13 @@
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/magefile/mage v1.10.0 h1:3HiXzCUY12kh9bIuyXShaVe529fJfyqoVM42o/uom2g=
+github.com/magefile/mage v1.10.0/go.mod h1:z5UZb/iS3GoOSn0JgWuiw7dxlurVYTu+/jHXqQg881A=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/sirupsen/logrus v1.8.0 h1:nfhvjKcUMhBMVqbKHJlk5RPrrfYr/NMo3692g0dwfWU=
+github.com/sirupsen/logrus v1.8.0/go.mod h1:4GuYW9TZmE769R5STWrRakJc4UqQ3+QQ95fyz7ENv1A=
+github.com/stretchr/testify v1.2.2 h1:bSDNvY7ZPG5RlJ8otE/7V6gMiyenm9RtJ7IUVIAoJ1w=
+github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
+golang.org/x/sys v0.0.0-20191026070338-33540a1f6037/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8 h1:0A+M6Uqn+Eje4kHMK80dtF3JCXC4ykBgQG4Fe06QRhQ=
+golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/pkg/update/testdata/bye/main.go
+++ b/pkg/update/testdata/bye/main.go
@@ -1,0 +1,17 @@
+/*
+Copyright 2022 Puerco J. Cerdo
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package main
+
+import (
+	"fmt"
+
+	"github.com/sirupsen/logrus"
+)
+
+func main() {
+	logrus.Info("preparing to say hi...")
+	fmt.Println("Hello World!")
+}


### PR DESCRIPTION
With the new version of gobump, we drop any replacement and require block of a dependency we want to add as require or replace.

However when we add a dep to the `deps` and this dependency appears on a replace block in the go.mod. We need to use the old.path of the dependency to be able to drop the existing replacement and use the proposed dep bump.

```
gobump --packages=golang.org/x/crypto@v1.17.0
```
To give an example, keda-2.9 has a replacement of the crypto dep that we want to bump https://github.com/kedacore/keda/blob/v2.9.1/go.mod#L99 and it also appears on a require block https://github.com/kedacore/keda/blob/v2.9.1/go.mod#L271. If we need to change the go.mod to use the new dep version, we need to drop the replace and require. 