### PR TITLE
Add support for tidy compat flag

### DIFF
--- a/cmd/gobump/root.go
+++ b/cmd/gobump/root.go
@@ -11,12 +11,13 @@ import (
 )
 
 type rootCLIFlags struct {
-	packages  string
-	modroot   string
-	replaces  string
-	goVersion string
-	tidy      bool
-	showDiff  bool
+	packages   string
+	modroot    string
+	replaces   string
+	goVersion  string
+	tidy       bool
+	showDiff   bool
+	tidyCompat string
 }
 
 var rootFlags rootCLIFlags
@@ -68,7 +69,7 @@ var rootCmd = &cobra.Command{
 			}
 		}
 
-		if _, err := update.DoUpdate(pkgVersions, &types.Config{Modroot: rootFlags.modroot, Tidy: rootFlags.tidy, GoVersion: rootFlags.goVersion, ShowDiff: rootFlags.showDiff}); err != nil {
+		if _, err := update.DoUpdate(pkgVersions, &types.Config{Modroot: rootFlags.modroot, Tidy: rootFlags.tidy, GoVersion: rootFlags.goVersion, ShowDiff: rootFlags.showDiff, TidyCompat: rootFlags.tidyCompat}); err != nil {
 			return fmt.Errorf("Failed to running update. Error: %v", err)
 		}
 		return nil
@@ -91,4 +92,5 @@ func init() {
 	flagSet.BoolVar(&rootFlags.tidy, "tidy", false, "Run 'go mod tidy' command")
 	flagSet.BoolVar(&rootFlags.showDiff, "show-diff", false, "Show the difference between the original and 'go.mod' files")
 	flagSet.StringVar(&rootFlags.goVersion, "go-version", "", "set the go-version for go-mod-tidy")
+	flagSet.StringVar(&rootFlags.tidyCompat, "compat", "", "set the go version for which the tidied go.mod and go.sum files should be compatible")
 }

--- a/pkg/run/gorun.go
+++ b/pkg/run/gorun.go
@@ -10,7 +10,7 @@ import (
 	versionutil "k8s.io/apimachinery/pkg/util/version"
 )
 
-func GoModTidy(modroot, goVersion string) (string, error) {
+func GoModTidy(modroot, goVersion, compat string) (string, error) {
 	if goVersion == "" {
 		cmd := exec.Command("go", "env", "GOVERSION")
 		cmd.Stderr = os.Stderr
@@ -25,7 +25,13 @@ func GoModTidy(modroot, goVersion string) (string, error) {
 	}
 
 	log.Printf("Running go mod tidy with go version '%s' ...\n", goVersion)
-	cmd := exec.Command("go", "mod", "tidy", "-go", goVersion)
+	args := []string{"mod", "tidy", "-go", goVersion}
+	if compat != "" {
+		log.Printf("Running go mod tidy with compat '%s' ...\n", compat)
+		args = append(args, "-compat", compat)
+	}
+
+	cmd := exec.Command("go", args...)
 	cmd.Dir = modroot
 	if bytes, err := cmd.CombinedOutput(); err != nil {
 		return strings.TrimSpace(string(bytes)), err

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -9,8 +9,9 @@ type Package struct {
 }
 
 type Config struct {
-	Modroot   string
-	GoVersion string
-	ShowDiff  bool
-	Tidy      bool
+	Modroot    string
+	GoVersion  string
+	ShowDiff   bool
+	Tidy       bool
+	TidyCompat string
 }

--- a/pkg/update/update.go
+++ b/pkg/update/update.go
@@ -84,7 +84,7 @@ func DoUpdate(pkgVersions map[string]*types.Package, cfg *types.Config) (*modfil
 	}
 	// Run go mod tidy before
 	if cfg.Tidy {
-		output, err := run.GoModTidy(cfg.Modroot, goVersion)
+		output, err := run.GoModTidy(cfg.Modroot, goVersion, cfg.TidyCompat)
 		if err != nil {
 			return nil, fmt.Errorf("failed to run 'go mod tidy': %v with output: %v", err, output)
 		}
@@ -132,7 +132,7 @@ func DoUpdate(pkgVersions map[string]*types.Package, cfg *types.Config) (*modfil
 
 	// Run go mod tidy
 	if cfg.Tidy {
-		output, err := run.GoModTidy(cfg.Modroot, goVersion)
+		output, err := run.GoModTidy(cfg.Modroot, goVersion, cfg.TidyCompat)
 		if err != nil {
 			return nil, fmt.Errorf("failed to run 'go mod tidy': %v with output: %v", err, output)
 		}


### PR DESCRIPTION
related to the discussion here: https://github.com/chainguard-dev/enterprise-packages/pull/1542

I've tested this flag using py3-seldon-core-1.16 package:

```
gobump --packages "golang.org/x/net@v0.17.0 golang.org/x/crypto@v0.17.0 github.com/emicklei/go-restful@v2.16.0" --tidy=true --show-diff=true --comp
at=1.17
2024/01/29 00:34:45 Running go mod tidy with go version '1.17' ...
2024/01/29 00:34:45 Running go mod tidy with compat '1.17' ...
2024/01/29 00:34:45 Update package: golang.org/x/net
2024/01/29 00:34:45 Running go mod edit -droprequire ...
2024/01/29 00:34:46 Running go get ...
2024/01/29 00:34:46 Update package: golang.org/x/crypto
2024/01/29 00:34:46 Running go mod edit -droprequire ...
2024/01/29 00:34:46 Running go get ...
2024/01/29 00:34:46 Update package: github.com/emicklei/go-restful
2024/01/29 00:34:46 Running go mod edit -droprequire ...
2024/01/29 00:34:46 Running go get ...
2024/01/29 00:34:47 Running go mod tidy with go version '1.17' ...
2024/01/29 00:34:47 Running go mod tidy with compat '1.17' ...
  (
  	"""
  	... // 40 identical lines
  		github.com/cespare/xxhash/v2 v2.1.2 // indirect
  		github.com/davecgh/go-spew v1.1.1 // indirect
- 		github.com/emicklei/go-restful v2.15.0+incompatible // indirect
+ 		github.com/emicklei/go-restful v2.16.0+incompatible // indirect
  		github.com/evanphx/json-patch v5.6.0+incompatible // indirect
  		github.com/evanphx/json-patch/v5 v5.6.0 // indirect
  	... // 28 identical lines
  		go.uber.org/atomic v1.9.0 // indirect
  		go.uber.org/multierr v1.6.0 // indirect
- 		golang.org/x/crypto v0.0.0-20220214200702-86341886e292 // indirect
- 		golang.org/x/net v0.0.0-20220624214902-1bab6f366d9e // indirect
+ 		golang.org/x/crypto v0.17.0 // indirect
+ 		golang.org/x/net v0.17.0 // indirect
  		golang.org/x/oauth2 v0.0.0-20220411215720-9780585627b5 // indirect
- 		golang.org/x/sys v0.0.0-20220627191245-f75cf1eec38b // indirect
- 		golang.org/x/term v0.0.0-20210927222741-03fcf44c2211 // indirect
- 		golang.org/x/text v0.3.7 // indirect
+ 		golang.org/x/sys v0.15.0 // indirect
+ 		golang.org/x/term v0.15.0 // indirect
+ 		golang.org/x/text v0.14.0 // indirect
  		golang.org/x/time v0.0.0-20220210224613-90d013bbcef8 // indirect
  		gomodules.xyz/jsonpatch/v2 v2.2.0 // indirect
  	... // 19 identical lines
  	"""
  )
  ```