### PR TITLE
add support to run go vendor commands

### DIFF
--- a/pkg/update/update.go
+++ b/pkg/update/update.go
@@ -159,6 +159,13 @@ func DoUpdate(pkgVersions map[string]*types.Package, cfg *types.Config) (*modfil
 		}
 	}
 
+	if _, err := os.Stat(path.Join(cfg.Modroot, "vendor")); err == nil {
+		output, err := run.GoVendor(cfg.Modroot)
+		if err != nil {
+			return nil, fmt.Errorf("failed to run 'go vendor': %v with output: %v", err, output)
+		}
+	}
+
 	return newModFile, nil
 }
 


### PR DESCRIPTION
We need to handle both `go work vendor` and `go mod vendor` when necessary. This should be done automatically without requiring a new flag from the users.