### PR TITLE
don't print usage when any error is encountered

### DIFF
--- a/cmd/gobump/root.go
+++ b/cmd/gobump/root.go
@@ -26,9 +26,10 @@ var rootFlags rootCLIFlags
 
 // rootCmd represents the base command when called without any subcommands.
 var rootCmd = &cobra.Command{
-	Use:   "gobump",
-	Short: "gobump cli",
-	Args:  cobra.NoArgs,
+	Use:          "gobump",
+	Short:        "gobump cli",
+	Args:         cobra.NoArgs,
+	SilenceUsage: true,
 	RunE: func(_ *cobra.Command, _ []string) error {
 		if rootFlags.packages == "" && rootFlags.replaces == "" && rootFlags.bumpFile == "" {
 			return fmt.Errorf("no packages or replaces provided. Use --packages or --replaces or --bump-file")


### PR DESCRIPTION
When gobump fails today for any reason, it prints its usage message. This can be helpful if the error is bad usage (undefined flag, etc.), but isn't really helpful when it's a genuine error, like when a go bump downgrades a dependency. In that case, printing usage is spammy at best, and could be misleading.